### PR TITLE
Added MacOS 13 builder

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -188,9 +188,52 @@ jobs:
           LIBREVNA_VERSION: "${{steps.id_version.outputs.app_version}}"
         uses: actions/upload-artifact@v4
         with:
-          name: LibreVNA-GUI-OSX-${{env.LIBREVNA_VERSION}}
+          name: LibreVNA-GUI-OSX-latest-${{env.LIBREVNA_VERSION}}
           path: Software/PC_Application/LibreVNA-GUI/LibreVNA-GUI.zip
+    
+  PC_Application_OSX_13:
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          brew install qt@6 pcre
           
+      - name: Set Environment
+        run: |
+          echo "/usr/local/opt/qt@6/bin" >> $GITHUB_PATH
+          
+      - name: Get build timestamp
+        id: id_date
+        run: echo "timestamp=$(date +%Y-%m-%d-%H-%M-%S)" >> $GITHUB_OUTPUT
+
+      - name: Get app version
+        id: id_version
+        run: |
+          cd Software/PC_Application/LibreVNA-GUI
+          fw_major=`pcregrep -o '(?<=FW_MAJOR=)[0-9]+' LibreVNA-GUI.pro`
+          fw_minor=`pcregrep -o '(?<=FW_MINOR=)[0-9]+' LibreVNA-GUI.pro`
+          fw_patch=`pcregrep -o '(?<=FW_PATCH=)[0-9]+' LibreVNA-GUI.pro` 
+          echo "app_version=v$fw_major.$fw_minor.$fw_patch-${{steps.id_date.outputs.timestamp}}" >> $GITHUB_OUTPUT
+
+      - name: Build application
+        run: |
+          cd Software/PC_Application/LibreVNA-GUI
+          qmake LibreVNA-GUI.pro
+          make -j9
+          macdeployqt LibreVNA-GUI.app
+          zip -ry LibreVNA-GUI.zip LibreVNA-GUI.app
+        shell: bash
+
+      - name: Upload artifact
+        env: 
+          LIBREVNA_VERSION: "${{steps.id_version.outputs.app_version}}"
+        uses: actions/upload-artifact@v4
+        with:
+          name: LibreVNA-GUI-OSX-13.7-${{env.LIBREVNA_VERSION}}
+          path: Software/PC_Application/LibreVNA-GUI/LibreVNA-GUI.zip
+  
   Embedded_Firmware:
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
To combat the "application can not run on this version of MacOS" errors - due to latest have a minimum compat version of MacOS 14 - we need to add another builder to ship an "Up-to-13.7" build.